### PR TITLE
Added op.gg link to player profiles on site

### DIFF
--- a/src/app/players/[slug]/page.tsx
+++ b/src/app/players/[slug]/page.tsx
@@ -29,6 +29,7 @@ import { redirect } from "next/navigation";
 import sortAccountsByRank from "util/sortAccountsByRank";
 import style from "./page.module.scss";
 import ugg from "util/ugg";
+import opgg from "util/opgg";
 
 /**
  * Parameters that are passed to a player page.
@@ -152,6 +153,8 @@ export default async function Page(
 									<>
 										{" | "}
 										<Link href={ugg(...accounts)}>{"U.GG"}</Link>
+										{" | "}
+										<Link href={opgg(...accounts)}>{"OP.GG"}</Link>
 									</>
 								)}
 							</h2>

--- a/src/util/opgg.ts
+++ b/src/util/opgg.ts
@@ -14,7 +14,7 @@ export default function opgg(
 ): string {
 	const [account] = accounts;
 	if (!account) {
-		return "https://u.gg/";
+		return "https://op.gg/";
 	}
 
 	if (accounts.length <= 1) {

--- a/src/util/opgg.ts
+++ b/src/util/opgg.ts
@@ -1,0 +1,24 @@
+import type { accountTable } from "db/schema";
+
+/**
+ * Make a U.GG link for the given set of accounts.
+ * @param accounts - The accounts to include in the U.GG link.
+ * @returns A U.GG link.
+ * @public
+ */
+export default function opgg(
+	...accounts: Pick<
+		typeof accountTable.$inferSelect,
+		"name" | "tagLine" | "region"
+	>[]
+): string {
+	const [account] = accounts;
+	if (!account) {
+		return "https://u.gg/";
+	}
+
+	if (accounts.length <= 1) {
+		return `https://op.gg/lol/summoners/${account.region}/${encodeURIComponent(account.name)}-${encodeURIComponent(account.tagLine)}`;
+	}
+  return `https://op.gg/lol/multisearch/na?summoners=${accounts.map(({ name, tagLine }) => `${encodeURIComponent(name)}%23${encodeURIComponent(tagLine)}`).join(",")}&region=${account.region.toLowerCase()}`;
+}


### PR DESCRIPTION
Adds a link alongside the u.gg link which links to a player's profiles on op.gg as an alternative requested by captains.