### PR TITLE
Fixed Draft

### DIFF
--- a/src/app/Topnav.tsx
+++ b/src/app/Topnav.tsx
@@ -48,6 +48,11 @@ export default async function Topnav({
 						<span>{"Leaderboards"}</span>
 					</Link>
 				</li>
+				<li className={style["hide-on-medium"]}>
+					<Link href="/draft">
+						<span>{"Draft"}</span>
+					</Link>
+				</li>
 				{session?.user ?
 					<>
 						<li className={style["right"]}>

--- a/src/app/draft/page.tsx
+++ b/src/app/draft/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import db from "db/db";
+import { desc } from "drizzle-orm";
+import getSeasonUrl from "util/getSeasonUrl";
+import { redirect } from "next/navigation";
+import { seasonTable } from "db/schema";
+
+/**
+ * Redirect to the latest season's draft page.
+ * @public
+ */
+export default async function Page(): Promise<never> {
+	const [latestSeason] = await db
+		.select()
+		.from(seasonTable)
+		.orderBy(desc(seasonTable.startDate))
+		.limit(1);
+
+	redirect(latestSeason ? `${getSeasonUrl(latestSeason)}/draft` : "/seasons");
+}
+
+/**
+ * The latest draft redirect page's metadata.
+ * @public
+ */
+export const metadata = {
+	description: "The latest Gauntlet Championship Series draft.",
+	openGraph: { url: "/draft" },
+	title: "Draft"
+} satisfies Metadata;

--- a/src/app/seasons/[slug]/AdminPanel.tsx
+++ b/src/app/seasons/[slug]/AdminPanel.tsx
@@ -5,6 +5,7 @@ import DeleteSeasonForm from "./admin/DeleteSeasonForm";
 import GenerateRegularSeasonForm from "./admin/GenerateRegularSeasonForm";
 import { type JSX } from "react";
 import Link from "components/Link";
+import StartDraftForm from "./admin/StartDraftForm";
 import UpdateSeasonForm from "./admin/UpdateSeasonForm";
 import getSeasonUrl from "util/getSeasonUrl";
 
@@ -43,6 +44,7 @@ export default function AdminPanel({
 				{"View players and assign point values."}
 			</Link>
 			<UpdateSeasonForm season={season} />
+			<StartDraftForm season={season} />
 			<CreateTeamForm season={season} />
 			<CreateMatchForm season={season} teams={teams} />
 			<GenerateRegularSeasonForm season={season} teams={teams} />

--- a/src/app/seasons/[slug]/admin/StartDraftForm.tsx
+++ b/src/app/seasons/[slug]/admin/StartDraftForm.tsx
@@ -1,0 +1,65 @@
+import Form, { type FormProps } from "components/Form";
+import type { JSX } from "react";
+import Submit from "components/Submit";
+import { auth } from "db/auth";
+import db from "db/db";
+import { eq } from "drizzle-orm";
+import getSeasonUrl from "util/getSeasonUrl";
+import { revalidatePath } from "next/cache";
+import { seasonTable } from "db/schema";
+
+/**
+ * Properties that can be passed to a start draft form.
+ * @public
+ */
+export interface StartDraftFormProps extends Omit<
+	FormProps,
+	"action" | "children"
+> {
+	/** The current season. */
+	season: typeof seasonTable.$inferSelect;
+}
+
+/**
+ * A form for allowing admins to start a season draft.
+ * @param props - Properties to pass to the form.
+ * @returns The form.
+ * @public
+ */
+export default function StartDraftForm({
+	season,
+	...props
+}: StartDraftFormProps): JSX.Element {
+	return (
+		<Form
+			action={async () => {
+				"use server";
+				const session = await auth();
+				if (!session?.user?.isAdmin) {
+					return "You must be an admin to start the draft.";
+				}
+
+				await db
+					.update(seasonTable)
+					.set({ draftStartedAt: new Date() })
+					.where(eq(seasonTable.id, season.id));
+				revalidatePath(getSeasonUrl(season));
+				revalidatePath(`${getSeasonUrl(season)}/draft`);
+				return void 0;
+			}}
+			{...props}
+		>
+			<header>
+				<h3>{"Draft"}</h3>
+			</header>
+			<p>
+				{season.draftStartedAt ?
+					"Drafting is open."
+				:	"Captains cannot draft players until an admin starts the draft."}
+			</p>
+			<p>
+				<Submit value="Start Draft" disabled={season.draftStartedAt !== null} />
+			</p>
+		</Form>
+	);
+}

--- a/src/app/seasons/[slug]/draft/DraftPlayerForm.tsx
+++ b/src/app/seasons/[slug]/draft/DraftPlayerForm.tsx
@@ -54,12 +54,7 @@ export default function DraftPlayerForm({
 	const highestRankedAccount = getHighestRankedAccount(accounts);
 
 	return (
-		<Form
-			action={async () =>
-				await draftPlayerAction(enabled ?? false, player, team)
-			}
-			{...props}
-		>
+		<Form action={async () => await draftPlayerAction(player, team)} {...props}>
 			<header>
 				<h3>
 					<Link href={getPlayerUrl(player)}>

--- a/src/app/seasons/[slug]/draft/Refresher.tsx
+++ b/src/app/seasons/[slug]/draft/Refresher.tsx
@@ -18,6 +18,7 @@ import { TEAM_SIZE } from "util/const";
 import type { Tree } from "types/Tree";
 import getDraftablePlayersRows from "./getDraftablePlayersRows";
 import getDraftedPlayersRows from "./getDraftedPlayersRows";
+import getNextDraftTeam from "./getNextDraftTeam";
 import getSeasonRows from "./getSeasonRows";
 import getTeamUrl from "util/getTeamUrl";
 import leftHierarchy from "util/leftHierarchy";
@@ -147,32 +148,12 @@ export default function Refresher({
 					) {
 						setCanDraft(false);
 					} else {
-						const [mostRecentDraft] = innerDraftedPlayers.sort(
-							(
-								{ draftPlayer: { draftedAt: a } },
-								{ draftPlayer: { draftedAt: b } }
-							) => (b?.valueOf() ?? 0) - (a?.valueOf() ?? 0)
+						const nextTeam = getNextDraftTeam(
+							teams.map(({ value }) => value),
+							innerDraftedPlayers.length
 						);
-						const teamsByDraftOrder = teams.sort(
-							({ value: { draftOrder: a } }, { value: { draftOrder: b } }) =>
-								a - b
-						);
-						const nextIndex =
-							(teamsByDraftOrder.findIndex(
-								({ value: { id } }) => id === mostRecentDraft?.team.id
-							) +
-								1) %
-							(teamsByDraftOrder.length * 2);
-						const nextTeam =
-							teamsByDraftOrder[
-								nextIndex < teamsByDraftOrder.length ?
-									nextIndex
-								:	teamsByDraftOrder.length -
-									1 -
-									(nextIndex - teamsByDraftOrder.length)
-							];
 
-						setCanDraft(nextTeam?.value.id === innerTeam.value.id);
+						setCanDraft(nextTeam?.id === innerTeam.value.id);
 					}
 
 					setLastUpdate(new Date());

--- a/src/app/seasons/[slug]/draft/Refresher.tsx
+++ b/src/app/seasons/[slug]/draft/Refresher.tsx
@@ -80,6 +80,7 @@ export default function Refresher({
 		>[]
 	>([]);
 	const [canDraft, setCanDraft] = useState(false);
+	const [isDraftStarted, setIsDraftStarted] = useState(false);
 	const [lastUpdate, setLastUpdate] = useState(new Date());
 
 	// Update state periodically.
@@ -95,6 +96,7 @@ export default function Refresher({
 
 					// Organize season, team, and drafted player data.
 					const { season } = first;
+					setIsDraftStarted(season.draftStartedAt !== null);
 					const teams = leftHierarchy(
 						seasonRows,
 						"team",
@@ -138,6 +140,7 @@ export default function Refresher({
 
 					// Determine whether the viewer is the next captain in line to draft a player.
 					if (
+						season.draftStartedAt === null ||
 						!session?.user ||
 						!innerTeam ||
 						innerTeam.children.length >= TEAM_SIZE ||
@@ -211,6 +214,13 @@ export default function Refresher({
 			<div className={style["draft"]}>
 				<header>
 					<h1>{"Draft"}</h1>
+					{!isDraftStarted && (
+						<p>
+							{
+								"Drafting has not started yet. Waiting for an admin to start the draft."
+							}
+						</p>
+					)}
 				</header>
 				<div>
 					{[

--- a/src/app/seasons/[slug]/draft/draftPlayerAction.ts
+++ b/src/app/seasons/[slug]/draft/draftPlayerAction.ts
@@ -1,29 +1,109 @@
 "use server";
 
-import { playerTable, teamPlayerTable, teamTable } from "db/schema";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import {
+	draftPlayerTable,
+	playerTable,
+	teamPlayerTable,
+	teamTable
+} from "db/schema";
+import { TEAM_SIZE } from "util/const";
+import { auth } from "db/auth";
 import db from "db/db";
+import getDraftedPlayersRows from "./getDraftedPlayersRows";
+import getNextDraftTeam from "./getNextDraftTeam";
 import { revalidatePath } from "next/cache";
 
 /**
  * Draft a player to a team.
- * @param enabled - Whether the user is allowed to draft a player.
  * @param player - The player to draft.
  * @param team - The team to draft the player to.
  * @returns An error message on failure only.
  * @public
  */
 export default async function draftPlayerAction(
-	enabled: boolean,
 	player: typeof playerTable.$inferSelect,
 	team?: typeof teamTable.$inferSelect
 ): Promise<string | undefined> {
-	if (!enabled || !team) {
+	const session = await auth();
+	if (!session?.user || !team) {
 		return "You aren't the drafting captain!";
+	}
+
+	const [draftingTeam] = await db
+		.select()
+		.from(teamTable)
+		.where(eq(teamTable.id, team.id))
+		.limit(1);
+	if (!draftingTeam) {
+		return "That team doesn't exist.";
+	}
+
+	const seasonTeamPlayersRows = await db
+		.select()
+		.from(teamPlayerTable)
+		.innerJoin(teamTable, eq(teamPlayerTable.teamId, teamTable.id))
+		.where(eq(teamTable.seasonId, draftingTeam.seasonId));
+	const draftingTeamPlayers = seasonTeamPlayersRows.filter(
+		({ teamPlayer }) => teamPlayer.teamId === draftingTeam.id
+	);
+
+	if (
+		draftingTeamPlayers.length >= TEAM_SIZE ||
+		!draftingTeamPlayers.some(
+			({ teamPlayer }) =>
+				teamPlayer.playerId === session.user?.id && teamPlayer.isCaptain
+		)
+	) {
+		return "You aren't the drafting captain!";
+	}
+
+	if (
+		seasonTeamPlayersRows.some(
+			({ teamPlayer }) => teamPlayer.playerId === player.id
+		)
+	) {
+		return "That player has already been drafted.";
+	}
+
+	const [draftPlayer] = await db
+		.select()
+		.from(draftPlayerTable)
+		.where(
+			and(
+				eq(draftPlayerTable.playerId, player.id),
+				eq(draftPlayerTable.seasonId, draftingTeam.seasonId),
+				isNotNull(draftPlayerTable.pointValue),
+				isNull(draftPlayerTable.draftedAt)
+			)
+		)
+		.limit(1);
+	if (!draftPlayer) {
+		return "That player isn't available to draft.";
+	}
+
+	const teams = await db
+		.select()
+		.from(teamTable)
+		.where(eq(teamTable.seasonId, draftingTeam.seasonId));
+	const draftedPlayers = await getDraftedPlayersRows(draftingTeam.seasonId);
+	const nextTeam = getNextDraftTeam(teams, draftedPlayers.length);
+	if (nextTeam?.id !== draftingTeam.id) {
+		return "It isn't your turn to draft.";
 	}
 
 	await db
 		.insert(teamPlayerTable)
-		.values({ playerId: player.id, teamId: team.id });
-	revalidatePath("");
+		.values({ playerId: player.id, teamId: draftingTeam.id });
+	await db
+		.update(draftPlayerTable)
+		.set({ draftedAt: new Date() })
+		.where(
+			and(
+				eq(draftPlayerTable.playerId, player.id),
+				eq(draftPlayerTable.seasonId, draftingTeam.seasonId)
+			)
+		);
+	revalidatePath("/seasons");
 	return void 0;
 }

--- a/src/app/seasons/[slug]/draft/draftPlayerAction.ts
+++ b/src/app/seasons/[slug]/draft/draftPlayerAction.ts
@@ -4,6 +4,7 @@ import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import {
 	draftPlayerTable,
 	playerTable,
+	seasonTable,
 	teamPlayerTable,
 	teamTable
 } from "db/schema";
@@ -37,6 +38,15 @@ export default async function draftPlayerAction(
 		.limit(1);
 	if (!draftingTeam) {
 		return "That team doesn't exist.";
+	}
+
+	const [season] = await db
+		.select()
+		.from(seasonTable)
+		.where(eq(seasonTable.id, draftingTeam.seasonId))
+		.limit(1);
+	if (!season?.draftStartedAt) {
+		return "The draft has not started yet.";
 	}
 
 	const seasonTeamPlayersRows = await db

--- a/src/app/seasons/[slug]/draft/getDraftedPlayersRows.ts
+++ b/src/app/seasons/[slug]/draft/getDraftedPlayersRows.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNotNull } from "drizzle-orm";
 import {
 	draftPlayerTable,
 	playerTable,
@@ -10,9 +10,9 @@ import {
 import db from "db/db";
 
 /**
- * Get draftable player information.
+ * Get drafted player information.
  * @param seasonId - The season ID.
- * @returns Draftable player information.
+ * @returns Drafted player information.
  * @public
  */
 export default async function getDraftedPlayersRows(seasonId: number) {
@@ -25,7 +25,8 @@ export default async function getDraftedPlayersRows(seasonId: number) {
 		.where(
 			and(
 				eq(draftPlayerTable.seasonId, seasonId),
-				eq(teamTable.seasonId, seasonId)
+				eq(teamTable.seasonId, seasonId),
+				isNotNull(draftPlayerTable.draftedAt)
 			)
 		);
 }

--- a/src/app/seasons/[slug]/draft/getNextDraftTeam.ts
+++ b/src/app/seasons/[slug]/draft/getNextDraftTeam.ts
@@ -1,0 +1,34 @@
+import { type teamTable } from "db/schema";
+
+/**
+ * A team participating in the draft.
+ */
+type DraftTeam = Pick<typeof teamTable.$inferSelect, "draftOrder">;
+
+/**
+ * Get the team that should make the next snake-draft pick.
+ * @param teams - The teams participating in the draft.
+ * @param draftedPlayerCount - The number of players already drafted.
+ * @returns The team whose turn is next, if any.
+ * @public
+ */
+export default function getNextDraftTeam<Team extends DraftTeam>(
+	teams: Team[],
+	draftedPlayerCount: number
+): Team | undefined {
+	const teamsByDraftOrder = [...teams].sort(
+		({ draftOrder: a }, { draftOrder: b }) => a - b
+	);
+
+	if (!teamsByDraftOrder.length) {
+		return void 0;
+	}
+
+	const pickIndex = draftedPlayerCount % (teamsByDraftOrder.length * 2);
+	const teamIndex =
+		pickIndex < teamsByDraftOrder.length ?
+			pickIndex
+		:	teamsByDraftOrder.length - 1 - (pickIndex - teamsByDraftOrder.length);
+
+	return teamsByDraftOrder[teamIndex];
+}

--- a/src/app/seasons/[slug]/draft/getSeasonRows.ts
+++ b/src/app/seasons/[slug]/draft/getSeasonRows.ts
@@ -8,8 +8,8 @@ import {
 	teamPlayerTable,
 	teamTable
 } from "db/schema";
+import { and, eq } from "drizzle-orm";
 import db from "db/db";
-import { eq } from "drizzle-orm";
 
 /**
  * Get season information.
@@ -24,7 +24,13 @@ export default async function getSeasonRows(slug: string) {
 		.leftJoin(teamTable, eq(seasonTable.id, teamTable.seasonId))
 		.leftJoin(teamPlayerTable, eq(teamTable.id, teamPlayerTable.teamId))
 		.leftJoin(playerTable, eq(teamPlayerTable.playerId, playerTable.id))
-		.leftJoin(draftPlayerTable, eq(playerTable.id, draftPlayerTable.playerId))
+		.leftJoin(
+			draftPlayerTable,
+			and(
+				eq(playerTable.id, draftPlayerTable.playerId),
+				eq(seasonTable.id, draftPlayerTable.seasonId)
+			)
+		)
 		.leftJoin(
 			accountTable,
 			eq(draftPlayerTable.playerId, accountTable.playerId)

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,6 +9,7 @@ import domain from "util/domain";
 export default function sitemap(): MetadataRoute.Sitemap {
 	return [
 		{ url: new URL("/api", domain).href },
+		{ url: new URL("/draft", domain).href },
 		{ url: new URL("/leaderboards", domain).href },
 		{ url: new URL("/players", domain).href },
 		{ url: new URL("/rulebook", domain).href },

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -260,6 +260,9 @@ export const tournamentProviderTable = pgTable("tournamentProvider", {
  * @public
  */
 export const seasonTable = pgTable("season", {
+	// The date and time at which admins opened the player draft. Null until drafting is allowed.
+	draftStartedAt: timestamp(),
+
 	// The Riot Games tournament ID. Returned by the Riot Games tournament API.
 	id: integer().primaryKey(),
 

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -8,7 +8,7 @@ export const TIME_SLOT_DURATION = 2;
  * The number of players on a team.
  * @public
  */
-export const TEAM_SIZE = 8;
+export const TEAM_SIZE = 5;
 
 /**
  * The ID of GCS season one.


### PR DESCRIPTION
- Ensure only the correct captain on the correct team can draft and that picks respect team size and player availability.
- Replace brittle next-team calculation with a reusable snake-draft helper for clarity and correctness.
- Tighten queries to only surface drafted players and to join draft data by season to avoid cross-season leakage.

- Simplified DraftPlayerForm action call to remove the enabled flag and pass only player and team to the action.
- Reworked draftPlayerAction to authenticate via auth, validate the drafting team and captain, enforce TEAM_SIZE, prevent  -duplicate drafts, verify draft availability (pointValue present and draftedAt null), determine turn via getNextDraftTeam, insert into teamPlayerTable, update draftPlayerTable.draftedAt, and call revalidatePath("/seasons").
- Added getNextDraftTeam which implements snake-draft ordering and is used by both Refresher and draftPlayerAction to determine whose turn is next.
- Updated Refresher to call getNextDraftTeam and set canDraft based on the returned team id.
- Adjusted getDraftedPlayersRows to only return rows where draftPlayerTable.draftedAt is not null.
- Tightened getSeasonRows join to include draftPlayerTable rows only when the seasonId matches the season being queried.