### PR TITLE
fix(bigint-overflow): preserve Riot game IDs as strings

### DIFF
--- a/src/app/api/riot/route.ts
+++ b/src/app/api/riot/route.ts
@@ -11,12 +11,12 @@ import {
 } from "db/schema";
 import { and, eq, or } from "drizzle-orm";
 import type TournamentGames from "types/riot/TournamentGames";
-import parseJsonSafe from "util/parseJsonSafe";
 import db from "db/db";
 import getFormatGameCount from "util/getFormatGameCount";
 import getPlatformForRegion from "util/getPlatformForRegion";
 import leftHierarchy from "util/leftHierarchy";
 import makeTournamentCodes from "riot/makeTournamentCodes";
+import parseJsonSafe from "util/parseJsonSafe";
 import saveGame from "util/saveGame";
 
 /**
@@ -24,7 +24,7 @@ import saveGame from "util/saveGame";
  * @public
  */
 export const POST = async (request: NextRequest): Promise<NextResponse> => {
-	const games = parseJsonSafe<TournamentGames[]>(await request.text());
+	const games = parseJsonSafe(await request.text()) as TournamentGames[];
 	if (games.length > 1) {
 		return new NextResponse(
 			"More than one game was returned. Did you use the same tournament code twice?",

--- a/src/app/api/riot/route.ts
+++ b/src/app/api/riot/route.ts
@@ -11,6 +11,7 @@ import {
 } from "db/schema";
 import { and, eq, or } from "drizzle-orm";
 import type TournamentGames from "types/riot/TournamentGames";
+import parseJsonSafe from "util/parseJsonSafe";
 import db from "db/db";
 import getFormatGameCount from "util/getFormatGameCount";
 import getPlatformForRegion from "util/getPlatformForRegion";
@@ -23,7 +24,7 @@ import saveGame from "util/saveGame";
  * @public
  */
 export const POST = async (request: NextRequest): Promise<NextResponse> => {
-	const games = (await request.json()) as TournamentGames[];
+	const games = parseJsonSafe<TournamentGames[]>(await request.text());
 	if (games.length > 1) {
 		return new NextResponse(
 			"More than one game was returned. Did you use the same tournament code twice?",

--- a/src/app/games/[slug]/page.tsx
+++ b/src/app/games/[slug]/page.tsx
@@ -265,7 +265,7 @@ export default async function Page(
 							.toString()
 							.padStart(2, "0")}`}
 					</p>
-					<p>{`Game ID: ${gameResult.value.id.toString()}`}</p>
+					<p>{`Game ID: ${gameResult.value.id}`}</p>
 					<p>{`Map: ${(await getMaps()).find((map) => map.mapId === gameResult.value.map)?.mapName ?? "Unknown"}`}</p>
 					<p>{`Mode: ${gameResult.value.mode}`}</p>
 					<p>{`Queue: ${queue ? `${queue.map}${queue.description ? ` - ${queue.description}` : ""}` : "Unknown"}`}</p>

--- a/src/app/leaderboards/page.tsx
+++ b/src/app/leaderboards/page.tsx
@@ -61,7 +61,7 @@ export default async function Page(): Promise<JSX.Element> {
 	);
 	const resultsByPlayer = leftHierarchy(rows, "player", "playerGameResult");
 	const killsPerTeam = rows.reduce((map, { playerGameResult }) => {
-		const key = `${playerGameResult.gameResultId.toString()}-${playerGameResult.team.toString()}`;
+		const key = `${playerGameResult.gameResultId}-${playerGameResult.team.toString()}`;
 		return map.set(key, (map.get(key) ?? 0) + playerGameResult.kills);
 	}, new Map<string, number>());
 
@@ -288,7 +288,7 @@ export default async function Page(): Promise<JSX.Element> {
 									(total, result) =>
 										total +
 										(killsPerTeam.get(
-											`${result.gameResultId.toString()}-${result.team.toString()}`
+											`${result.gameResultId}-${result.team.toString()}`
 										) ?? 0),
 									0
 								),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -474,8 +474,9 @@ export const gameResultTable = pgTable("gameResult", {
 	// The duration of the game in milliseconds.
 	duration: integer().notNull(),
 
-	// The game ID of the game in the Riot API.
-	id: bigint({ mode: "number" }).primaryKey(),
+	// The game ID of the game in the Riot API. Stored as varchar because Riot game IDs
+	// exceed JavaScript's safe integer range and must not be coerced to Number.
+	id: varchar({ length: 20 }).primaryKey(),
 
 	// The ID of the map that the game was played on.
 	map: integer().notNull(),
@@ -510,7 +511,7 @@ export const teamGameResultTable = pgTable(
 	"teamGameResult",
 	{
 		// The ID of the game result that these results correspond to.
-		gameResultId: bigint({ mode: "number" })
+		gameResultId: varchar({ length: 20 })
 			.references(() => gameResultTable.id, {
 				onDelete: "cascade",
 				onUpdate: "cascade"
@@ -550,7 +551,7 @@ export const teamGameResultBanTable = pgTable(
 		champ: integer().notNull(),
 
 		// The ID of the game result that these results correspond to.
-		gameResultId: bigint({ mode: "number" })
+		gameResultId: varchar({ length: 20 })
 			.references(() => gameResultTable.id, {
 				onDelete: "cascade",
 				onUpdate: "cascade"
@@ -595,7 +596,7 @@ export const playerGameResultTable = pgTable(
 		enemyJgCs: integer().notNull(),
 
 		// The ID of the game result that these results correspond to.
-		gameResultId: bigint({ mode: "number" })
+		gameResultId: varchar({ length: 20 })
 			.references(() => gameResultTable.id, {
 				onDelete: "cascade",
 				onUpdate: "cascade"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -474,8 +474,7 @@ export const gameResultTable = pgTable("gameResult", {
 	// The duration of the game in milliseconds.
 	duration: integer().notNull(),
 
-	// The game ID of the game in the Riot API. Stored as varchar because Riot game IDs
-	// exceed JavaScript's safe integer range and must not be coerced to Number.
+	// The game ID. Stored as varchar because Riot game IDs exceed Number.MAX_SAFE_INTEGER.
 	id: varchar({ length: 20 }).primaryKey(),
 
 	// The ID of the map that the game was played on.

--- a/src/riot/getMatchDto.ts
+++ b/src/riot/getMatchDto.ts
@@ -23,5 +23,5 @@ export default async function getMatchDto(
 		void 0,
 		key
 	);
-	return parseJsonSafe<MatchDto>(await response.text());
+	return parseJsonSafe(await response.text()) as MatchDto;
 }

--- a/src/riot/getMatchDto.ts
+++ b/src/riot/getMatchDto.ts
@@ -1,6 +1,7 @@
 import Cluster from "types/riot/Cluster";
 import type MatchDto from "types/riot/MatchDto";
 import getRiotApiBaseUrl from "./getRiotApiBaseUrl";
+import parseJsonSafe from "util/parseJsonSafe";
 import riotFetch from "./riotFetch";
 
 /**
@@ -17,11 +18,10 @@ export default async function getMatchDto(
 	cluster = Cluster.AMERICAS,
 	key: string | undefined = void 0
 ): Promise<MatchDto> {
-	return (await (
-		await riotFetch(
-			new URL(`/lol/match/v5/matches/${id}`, getRiotApiBaseUrl(cluster)).href,
-			void 0,
-			key
-		)
-	).json()) as MatchDto;
+	const response = await riotFetch(
+		new URL(`/lol/match/v5/matches/${id}`, getRiotApiBaseUrl(cluster)).href,
+		void 0,
+		key
+	);
+	return parseJsonSafe<MatchDto>(await response.text());
 }

--- a/src/types/riot/InfoDto.ts
+++ b/src/types/riot/InfoDto.ts
@@ -20,8 +20,8 @@ export default interface InfoDto {
 	/** The Unix timestamp at which the game ended on the game server. Can occasionally be significantly later than when the match actually ends, so it is better to determine the timestamp of the end of the match by adding the `gameDuration` to the `gameStartTimestamp`. Added on patch 11.20. */
 	gameEndTimestamp?: number;
 
-	/** The game's ID. */
-	gameId: number;
+	/** The game's ID. Typed as string because Riot game IDs exceed JavaScript's safe integer range. */
+	gameId: string;
 
 	/** The game's mode. */
 	gameMode: string;

--- a/src/types/riot/TournamentGames.ts
+++ b/src/types/riot/TournamentGames.ts
@@ -18,8 +18,8 @@ export default interface TournamentGames {
 	/** The metadata associated with the game's tournament code. */
 	metaData: string;
 
-	/** The game's ID. */
-	gameId: number;
+	/** The game's ID. Typed as string because Riot game IDs exceed JavaScript's safe integer range. */
+	gameId: string;
 
 	/** The game's name. */
 	gameName: string;

--- a/src/util/createForfeit.ts
+++ b/src/util/createForfeit.ts
@@ -30,7 +30,7 @@ export default function createForfeit(
 	]
 ] {
 	const now = Date.now();
-	const id = -now;
+	const id = (-now).toString();
 
 	return [
 		{

--- a/src/util/makeMatchId.ts
+++ b/src/util/makeMatchId.ts
@@ -8,8 +8,8 @@ import Platform from "types/riot/Platform";
  * @public
  */
 export default function makeMatchId(
-	gameId: number | `${number}`,
+	gameId: string,
 	platform: Platform = Platform.NA1
-): `${Platform}_${number}` {
-	return `${platform}_${gameId.toString() as `${number}`}`;
+): `${Platform}_${string}` {
+	return `${platform}_${gameId}`;
 }

--- a/src/util/parseJsonSafe.ts
+++ b/src/util/parseJsonSafe.ts
@@ -2,13 +2,18 @@
  * Parse a JSON string while preserving large integers (≥ 16 digits) as strings.
  *
  * JavaScript's JSON.parse coerces all numbers to IEEE 754 doubles, silently
- * losing precision for integers outside the safe range (> 2^53 − 1). Riot game
+ * losing precision for integers outside the safe range (\> 2^53 − 1). Riot game
  * IDs are ~19 digits and hit this limit. This function quotes any bare integer
  * with 16 or more digits before parsing, so they arrive as strings instead.
  *
  * The replacement only applies to unquoted JSON values (after `:` or `,` or `[`),
  * so integers already inside strings are unaffected.
  */
-export default function parseJsonSafe<T>(text: string): T {
-	return JSON.parse(text.replace(/([:,\[])\s*(-?\d{16,})/g, '$1"$2"')) as T;
+export default function parseJsonSafe(text: string): unknown {
+	return JSON.parse(
+		text.replace(
+			/(?<prefix>[:,\x5B])\s*(?<value>-?\d{16,})/gu,
+			'$<prefix>"$<value>"'
+		)
+	);
 }

--- a/src/util/parseJsonSafe.ts
+++ b/src/util/parseJsonSafe.ts
@@ -1,0 +1,14 @@
+/**
+ * Parse a JSON string while preserving large integers (≥ 16 digits) as strings.
+ *
+ * JavaScript's JSON.parse coerces all numbers to IEEE 754 doubles, silently
+ * losing precision for integers outside the safe range (> 2^53 − 1). Riot game
+ * IDs are ~19 digits and hit this limit. This function quotes any bare integer
+ * with 16 or more digits before parsing, so they arrive as strings instead.
+ *
+ * The replacement only applies to unquoted JSON values (after `:` or `,` or `[`),
+ * so integers already inside strings are unaffected.
+ */
+export default function parseJsonSafe<T>(text: string): T {
+	return JSON.parse(text.replace(/([:,\[])\s*(-?\d{16,})/g, '$1"$2"')) as T;
+}

--- a/src/util/saveGame.ts
+++ b/src/util/saveGame.ts
@@ -23,7 +23,7 @@ import makeMatchId from "./makeMatchId";
  * @public
  */
 export default async function saveGame(
-	id: number | `${number}`,
+	id: string,
 	puuids?: Map<number, string[]>,
 	game?: Pick<typeof gameTable.$inferSelect, "tournamentCode" | "id">,
 	platform: Platform = Platform.NA1
@@ -32,9 +32,7 @@ export default async function saveGame(
 	const [existingResult] = await db
 		.select()
 		.from(gameResultTable)
-		.where(
-			eq(gameResultTable.id, typeof id === "number" ? id : parseInt(id, 10))
-		)
+		.where(eq(gameResultTable.id, id))
 		.limit(1);
 	if (existingResult) {
 		if (


### PR DESCRIPTION
QUICK OVERVIEW ~> GCS Website is failing to ingest the riot match id data - I'm 99% sure it's due to an overflow int problem, this PR is a fix for that. I can't actually test it bc I don't have access to the DB or the tourney api key - so wrote down some steps below

## Summary
  - Riot game IDs are ~19 digits and exceed JavaScript's safe integer range (2^53 − 1). `JSON.parse` silently corrupts them (e.g. `7153744765634543617` → `7153744765634544000`).
  - Add `parseJsonSafe<T>` utility that quotes bare integers ≥ 16 digits before parsing so they arrive as strings instead of corrupted numbers.
  - Thread `string` types for game IDs through every affected layer: `TournamentGames`, `InfoDto`, `saveGame`, `makeMatchId`, `createForfeit`, and the DB schema.
  
  ## Changes
  - `src/util/parseJsonSafe.ts` — new utility; regex-quotes large ints before `JSON.parse`
  - `src/app/api/riot/route.ts` — replace `request.json()` with `parseJsonSafe`
  - `src/riot/getMatchDto.ts` — replace `response.json()` with `parseJsonSafe`
  - `src/types/riot/InfoDto.ts` + `TournamentGames.ts` — `gameId: string` (was `number`)
  - `src/db/schema.ts` — `gameResult.id` and 3 FK `gameResultId` fields: `varchar(20)` (was `bigint`)
  - `src/util/saveGame.ts` — `id` param `string`; drop `parseInt` branch
  - `src/util/makeMatchId.ts` — param and return type updated to `string`
  - `src/util/createForfeit.ts` — `id = (-now).toString()` to match varchar FK type

  ## Deployment steps (pls do this before going live - otherwise changes won't really make sense - feel free to test this out yourself too)
  1. Run Drizzle schema push to sync the column type change to the DB:
     ```bash
     POSTGRES_URL=<connection-string> npm run drizzlePush
     This migrates gameResult.id and the three gameResultId FK columns from bigint → varchar(20).
     
  2. Re-import any existing game results (prob for S4) rows stored under the old bigint column will have corrupted IDs and should be re-fetched from the Riot API.

  Test plan (generated by chat but i dont have access to ur infra or tournament api key so this looks roughly right) 
  - [ ] drizzlePush succeeds against staging DB
  - [ ] Tournament callback (POST /api/riot) stores gameId as correct string
  - [ ] getMatchDto returns correct gameId string on a real game
  - [ ] Forfeit creation stores a negative string ID without FK violation